### PR TITLE
ListField and EmbeddedDocumentField require patch_mongoengine_field

### DIFF
--- a/django_mongoengine/fields/__init__.py
+++ b/django_mongoengine/fields/__init__.py
@@ -31,5 +31,7 @@ def patch_mongoengine_field(field_name):
         if not k in field.__dict__:
             setattr(field, k, djangoflavor.DjangoField.__dict__[k])
 
-for f in ["StringField", "ObjectIdField"]:
+for f in ["StringField", "ObjectIdField",
+          "ListField", "EmbeddedDocumentField"
+          ]:
     patch_mongoengine_field(f)


### PR DESCRIPTION
Resolves (in addition to ___) the `AttributeError: 'DateTimeField' object has no attribute 'attname'` Issue encountered with the LDAP Plug-in (NSE-2218)

See Also:
 * https://github.com/MongoEngine/django-mongoengine/issues/95
 * https://github.com/MongoEngine/django-mongoengine/compare/95_fix-swagger
